### PR TITLE
Adding ship_address_country and bill_address_country promo rule

### DIFF
--- a/promo/app/models/spree/promotion/rules/bill_address_country.rb
+++ b/promo/app/models/spree/promotion/rules/bill_address_country.rb
@@ -1,0 +1,15 @@
+module Spree
+  class Promotion
+    module Rules
+      class BillAddressCountry < PromotionRule
+        preference :country_id, :integer, :default => Spree::Config.default_country_id
+        
+        attr_accessible :preferred_country_id
+        
+        def eligible?(order, options = {})
+          (order.billing_address.try(:country_id) == preferred_country_id)
+        end
+      end
+    end
+  end
+end

--- a/promo/app/models/spree/promotion/rules/ship_address_country.rb
+++ b/promo/app/models/spree/promotion/rules/ship_address_country.rb
@@ -1,0 +1,15 @@
+module Spree
+  class Promotion
+    module Rules
+      class ShipAddressCountry < PromotionRule
+        preference :country_id, :integer, :default => Spree::Config.default_country_id
+        
+        attr_accessible :preferred_country_id
+        
+        def eligible?(order, options = {})
+          (order.shipping_address.try(:country_id) == preferred_country_id)
+        end
+      end
+    end
+  end
+end

--- a/promo/app/views/spree/admin/promotions/rules/_bill_address_country.html.erb
+++ b/promo/app/views/spree/admin/promotions/rules/_bill_address_country.html.erb
@@ -1,0 +1,3 @@
+<div class="field alpha four columns">
+  <%= collection_select "#{param_prefix}", :preferred_country_id, Spree::Country.order('name ASC').all, :id, :name, { selected: promotion_rule.preferred_country_id } %>
+</div>

--- a/promo/app/views/spree/admin/promotions/rules/_ship_address_country.html.erb
+++ b/promo/app/views/spree/admin/promotions/rules/_ship_address_country.html.erb
@@ -1,0 +1,3 @@
+<div class="field alpha four columns">
+  <%= collection_select "#{param_prefix}", :preferred_country_id, Spree::Country.order('name ASC').all, :id, :name, { selected: promotion_rule.preferred_country_id } %>
+</div>

--- a/promo/config/locales/en.yml
+++ b/promo/config/locales/en.yml
@@ -72,6 +72,12 @@ en:
   promotions_description: Manage offers and coupons with promotions
   promotion_rule: Promotion Rule
   promotion_rule_types:
+    bill_address_country:
+      name: Bill Address Country
+      description: "Only valid for this country's billing address"
+    ship_address_country:
+      name: Ship Address Country
+      description: "Only valid for this country's shipping address"
     product_exclusion:
       name: Product Exclusion(s)
       description: "Order does not include specified product(s)"

--- a/promo/lib/spree/promo/engine.rb
+++ b/promo/lib/spree/promo/engine.rb
@@ -45,7 +45,9 @@ module Spree
           Spree::Promotion::Rules::FirstOrder,
           Spree::Promotion::Rules::UserLoggedIn,
           Spree::Promotion::Rules::CurrentStore,
-          Spree::Promotion::Rules::ProductExclusion]
+          Spree::Promotion::Rules::ProductExclusion,
+          Spree::Promotion::Rules::ShipAddressCountry,
+          Spree::Promotion::Rules::BillAddressCountry]
       end
 
       initializer 'spree.promo.register.promotions.actions' do |app|

--- a/promo/spec/models/promotion/rules/bill_address_country_spec.rb
+++ b/promo/spec/models/promotion/rules/bill_address_country_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe Spree::Promotion::Rules::BillAddressCountry do
+
+  let(:rule) { Spree::Promotion::Rules::BillAddressCountry.new }
+  let(:order) { mock_model(Spree::Order ) }
+  let(:billing_address) {FactoryGirl.create(:address, :country_id => 1)}
+  
+  it "should be eligible with a matching country_id" do
+    order.stub :billing_address => billing_address
+    rule.stub(:preferred_country_id => 1)
+    rule.should be_eligible(order)
+  end
+
+  it "should not be eligible with a non-matching country_id" do
+    order.stub :billing_address => mock(:address, :country_id => 3)
+    rule.stub(:preferred_country_id => 49)
+    rule.should_not be_eligible(order)
+  end
+end

--- a/promo/spec/models/promotion/rules/ship_address_country_spec.rb
+++ b/promo/spec/models/promotion/rules/ship_address_country_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe Spree::Promotion::Rules::ShipAddressCountry do
+
+  let(:rule) { Spree::Promotion::Rules::ShipAddressCountry.new }
+  let(:order) { mock_model(Spree::Order ) }
+  let(:ship_address) {FactoryGirl.create(:address, :country_id => 1)}
+  
+  it "should be eligible with a matching country_id" do
+    order.stub :shipping_address => ship_address
+    rule.stub(:preferred_country_id => 1)
+    rule.should be_eligible(order)
+  end
+
+  it "should not be eligible with a non-matching country_id" do
+    order.stub :shipping_address => mock(:address, :country_id => 3)
+    rule.stub(:preferred_country_id => 49)
+    rule.should_not be_eligible(order)
+  end
+end


### PR DESCRIPTION
Added two new promotion rules:
1) Ship Address Country 
    Description: Only valid for this country's shipping address
2) Bill Address Country
    Description: Only valid for this country's billing address
3) Added country drop down in the rule defaulted to United States.
4) The coupon would be applied only if the billing/shipping address of the order matches the selected country in its corresponding rule.
