### PR TITLE
Feature/non locking atomic update on inventory update

### DIFF
--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -48,8 +48,6 @@ module Spree
     def self.increase(order, variant, quantity)
       # Adding pessimistic locking, but only if we actually need to update
       # the inventory.
-
-      # Defining back_order and sold at top scope
       back_order = 0
       sold = 0
       if self.track_levels?(variant)
@@ -79,7 +77,7 @@ module Spree
 
     def self.decrease(order, variant, quantity)
       if self.track_levels?(variant)
-        # Grabbing pesssimistic lock, which will also reload the model. See
+        # Grabbing pesssimistic lock, which will alos reload the model. See
         # other notes about locking in self.increase above.
         variant.with_lock do
           variant.increment!(:count_on_hand, quantity)


### PR DESCRIPTION
We still had a few problems caused by the pessimistic lock because of deadlocks. The reality is, in this place in the order checkout process, where the payment has been received and we want to fulfill the order, we do not care about locking on the variant table. All we care about is adjusting the inventory accurately and immediately without putting the order at risk of having its after_complete callback fail. So I'm just going to disable optimistic locking and do an atomic SQL query. The ActiveRecord update_counters method will result in a SQL statement that looks like this:

UPDATE "spree_variants" SET "count_on_hand" = COALESCE("count_on_hand", 0) - 1 WHERE "spree_variants"."id" = 12077
