### PR TITLE
Fix a syntax error by using after(:create)

### DIFF
--- a/core/lib/spree/core/testing_support/factories/calculator_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/calculator_factory.rb
@@ -1,9 +1,9 @@
 FactoryGirl.define do
   factory :calculator, :class => Spree::Calculator::FlatRate do
-    after_create { |c| c.set_preference(:amount, 10.0) }
+    after(:create) { |c| c.set_preference(:amount, 10.0) }
   end
 
   factory :no_amount_calculator, :class => Spree::Calculator::FlatRate do
-    after_create { |c| c.set_preference(:amount, 0) }
+    after(:create) { |c| c.set_preference(:amount, 0) }
   end
 end


### PR DESCRIPTION
This is required to get the calculator factory working properly
